### PR TITLE
Removes the title and description option

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -34,7 +34,6 @@ class Gateway extends \WC_Payment_Gateway {
 		$this->init_form_fields();
 		$this->init_settings();
 
-		$this->title       = $this->get_option( 'title' );
 		$this->description = $this->get_option( 'description' );
 		$this->enabled     = $this->get_option( 'enabled' );
 		$this->has_fields  = true;

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -73,20 +73,6 @@ class Settings {
 				'title' => __( 'Checkout settings', 'ledyer-payments-for-woocommerce' ),
 				'type'  => 'title',
 			),
-			'title'                    => array(
-				'title'       => __( 'Title', 'ledyer-payments-for-woocommerce' ),
-				'type'        => 'text',
-				'description' => __( 'The payment gateway title (appears on checkout page if more than one payment method is available).', 'ledyer-payments-for-woocommerce' ),
-				'default'     => 'Ledyer Payments',
-			),
-			'redirect_description'     => array(
-				'title'       => __( 'Description', 'ledyer-payments-for-woocommerce' ),
-				'type'        => 'textarea',
-				'description' => __( 'The payment gateway method description (appears on checkout page if more than one payment method is available).', 'ledyer-payments-for-woocommerce' ),
-				'default'     => '',
-				'placeholder' => __( 'Choose your payment method in our checkout.', 'ledyer-payments-for-woocommerce' ),
-				'class'       => 'redirect-only',
-			),
 			'company_number_placement' => array(
 				'title'       => __( 'Company number field', 'ledyer-payments-for-woocommerce' ),
 				'type'        => 'select',


### PR DESCRIPTION
These settings are never used. Both fields, even if set, are always overwritten in `payment-categories.php`.