### PR TITLE
remove plugin uri

### DIFF
--- a/ledyer-payments-for-woocommerce.php
+++ b/ledyer-payments-for-woocommerce.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Plugin Name: Ledyer Payments for WooCommerce
- * Plugin URI: https://krokedil.com/
  * Description: Ledyer Payments for WooCommerce.
  * Author: Krokedil
  * Author URI: https://krokedil.com/


### PR DESCRIPTION
from wordpress.org when trying to deploy:

"Error: Your plugin and author URIs are the same. Your plugin headers in the main plugin file headers have the same value for both the plugin and author URI (Uniform Resource Identifier). A plugin URI is a webpage that provides details about this specific plugin. An author URI is a webpage that provides information about the author of the plugin. Those two must be different. You are not required to provide both, so pick the one that best applies to your situation."

Plugin URI is not mandatory and may be added later